### PR TITLE
Improve image artifact handling

### DIFF
--- a/blog_writer_agents/agent.py
+++ b/blog_writer_agents/agent.py
@@ -21,7 +21,7 @@ load_dotenv()
 logging.basicConfig(level=logging.ERROR)
 
 MODEL = "gemini-2.5-pro-preview-05-06"
-IMAGE_FILE_NAME = os.getenv("IMAGE_FILE_NAME")
+IMAGE_FILE_NAME = os.getenv("IMAGE_FILE_NAME", "image.png")
 
 BLOG_COORDINATOR_PROMPT = """
 マーケティングとコンテンツ戦略の専門家です。あなたの目的は、ユーザーが魅力的なブログ記事を作成し、多くの反響を得られるようにサポートすることです。

--- a/blog_writer_agents/tools/generate_image.py
+++ b/blog_writer_agents/tools/generate_image.py
@@ -25,12 +25,13 @@ async def generate_image(prompt: str, tool_context: 'ToolContext'):
     if not response.generated_images:
         return {"status": "failed"}
     image_bytes = response.generated_images[0].image.image_bytes
+    image_name = os.getenv("IMAGE_FILE_NAME", "image.png")
     await tool_context.save_artifact(
-        "image.png",
+        image_name,
         types.Part.from_bytes(data=image_bytes, mime_type="image/png"),
     )
     return {
-        'status': 'success',
-        'detail': 'Image generated successfully and stored in artifacts.',
-        'filename': os.getenv("IMAGE_FILE_NAME"),
+        "status": "success",
+        "detail": "Image generated successfully and stored in artifacts.",
+        "filename": image_name,
     }

--- a/deploy.py
+++ b/deploy.py
@@ -23,10 +23,16 @@ flags.mark_bool_flags_as_mutual_exclusive(["create", "delete"])
 
 def create() -> None:
     """新しいエージェントを作成"""
-    adk_app = reasoning_engines.AdkApp(agent=root_agent, enable_tracing=True)
+    env_vars = {"IMAGE_FILE_NAME": os.getenv("IMAGE_FILE_NAME", "image.png")}
+
+    adk_app = reasoning_engines.AdkApp(
+        agent=root_agent,
+        enable_tracing=True,
+    )
 
     remote_agent = agent_engines.create(
         adk_app,
+        env_vars=env_vars,
         display_name=root_agent.name,
         requirements=[
             "google-adk (>=0.0.2)",


### PR DESCRIPTION
## Summary
- pass `IMAGE_FILE_NAME` via `agent_engines.create`
- save image artifact using provided filename
- ensure a default filename when loading artifacts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f9f65fe34832abbfc2c313769e7e4