### PR TITLE
Add datetime tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - **Researcher Agent**: キーワードに基づくブログ記事のアイデアを提案します。
 - **Blog Editor Agent**: 選択したテーマからプロフェッショナルな記事を生成します。
 - **Image Generator Tool**: ブログ用のアイキャッチ画像を作成します。
+- **Datetime Tool**: 現在の年月日と時刻を取得します。
 - **Streamlit UI**: チャット形式でエージェントとやり取りできる簡易 UI を提供します。
 
 ## 構成図

--- a/blog_writer_agents/agent.py
+++ b/blog_writer_agents/agent.py
@@ -14,6 +14,7 @@ from dotenv import load_dotenv
 from .sub_agents.researcher import researcher_agent
 from .sub_agents.blog_editor import blog_editor_agent
 from .tools.generate_image import generate_image
+from .tools.get_current_datetime import get_current_datetime
 from google.adk.tools import load_artifacts
 from google.genai.types import Part
 from google.adk.agents.callback_context import CallbackContext
@@ -129,6 +130,7 @@ blog_coordinator = LlmAgent(
         AgentTool(agent=researcher_agent),
         AgentTool(agent=blog_editor_agent),
         generate_image,
+        get_current_datetime,
         load_artifacts
     ],
     sub_agents=[],

--- a/blog_writer_agents/tools/get_current_datetime.py
+++ b/blog_writer_agents/tools/get_current_datetime.py
@@ -1,0 +1,8 @@
+import datetime
+from google.adk.tools import ToolContext
+
+
+async def get_current_datetime(_: str, tool_context: ToolContext):
+    """Return the current date and time."""
+    now = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    return {"current_datetime": now}


### PR DESCRIPTION
## Summary
- add `get_current_datetime` tool for retrieving the current date and time
- hook the new tool into the root agent
- document the Datetime Tool in README

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b6d83f4b4832a9a297bb9e8042100