### PR TITLE
Switch model names to GA versions

### DIFF
--- a/blog_writer_agents/agent.py
+++ b/blog_writer_agents/agent.py
@@ -24,7 +24,7 @@ from typing import Optional
 load_dotenv()
 logging.basicConfig(level=logging.ERROR)
 
-MODEL = "gemini-2.5-pro-preview-05-06"
+MODEL = "gemini-2.5-pro"
 IMAGE_FILE_NAME = os.getenv("IMAGE_FILE_NAME", "image.png")
 
 BLOG_COORDINATOR_PROMPT = """

--- a/blog_writer_agents/sub_agents/blog_editor/agent.py
+++ b/blog_writer_agents/sub_agents/blog_editor/agent.py
@@ -4,7 +4,7 @@ from google.adk import Agent
 
 from . import prompt
 
-MODEL = "gemini-2.5-pro-preview-05-06"
+MODEL = "gemini-2.5-pro"
 
 blog_editor_agent = Agent(
     model=MODEL,

--- a/blog_writer_agents/sub_agents/researcher/agent.py
+++ b/blog_writer_agents/sub_agents/researcher/agent.py
@@ -11,7 +11,7 @@ from typing import Optional
 from . import prompt
 
 logging.basicConfig(level=logging.INFO, force=True)
-MODEL = "gemini-2.5-flash-preview-05-20"
+MODEL = "gemini-2.5-flash"
 
 
 def grounding_metadata_callback(


### PR DESCRIPTION
## Summary
- use `gemini-2.5-pro` for the coordinator and blog editor
- use `gemini-2.5-flash` for the researcher

## Testing
- `pip install -r requirements-dev.txt`
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_685254de8b78832ab96803a7d21b0cba